### PR TITLE
Don't encode '!' with uri_encode

### DIFF
--- a/lib/URI/Encode.pm6
+++ b/lib/URI/Encode.pm6
@@ -12,7 +12,7 @@ module URI::Encode:ver<0.04>
 
     sub uri_encode (Str:D $text) is export
     {
-      return $text.subst(/<[\x00..\xff]-[a..zA..Z0..9_.~\-\#\$\&\+,\/\:;\=\?@]>/, *.ord.fmt('%%%02X'), :g);
+      return $text.subst(/<[\x00..\xff]-[a..zA..Z0..9_.~\!\+\-\#\$\&\+,\/\:;\=\?@]>/, *.ord.fmt('%%%02X'), :g);
     }
 
     sub uri_encode_component (Str:D $text) is export

--- a/t/Encode.t
+++ b/t/Encode.t
@@ -3,7 +3,7 @@ use Test;
 use lib './lib';
 use URI::Encode;
 
-plan 16;
+plan 18;
 
 # encode
 is uri_encode("  "),    "%20%20",       'Encode "   "';
@@ -11,11 +11,13 @@ is uri_encode("|abcå"), "%7Cabc%E5",    'Encode "|abcå"';
 is uri_encode("abc"),   "abc",          'Encode "abc"';
 is uri_encode("~*'()"), "~%2A%27%28%29",'Encode "~*\'()"';
 is uri_encode("<\">"),  "%3C%22%3E",    'Encode "<\"';
+is uri_encode("Hello World!"), "Hello%20World!", 'Encode "Hello World!"';
 is uri_encode("http://perltricks.com/"),  "http://perltricks.com/",
   'Encode "http://perltricks.com/"';
 is uri_encode("https://perltricks.com/"), "https://perltricks.com/",
   'Encode "https://perltricks.com/"';
 
+is uri_encode_component("Hello World!"), "Hello%20World%21", 'Encode components "Hello World!"';
 is uri_encode_component('#$&+,/:;=?@'), '%23%24%26%2B%2C%2F%3A%3B%3D%3F%40',
   'Encode components \'#$&+,/:;=?@\'';
 


### PR DESCRIPTION
Fixes #6 in part

I''ve just changed enough so that it URI::Template passes the tests based on https://tools.ietf.org/html/rfc6570 however you might want to consider adding all the delimiting reserved characters in https://tools.ietf.org/html/rfc3986#section-2.2 to those ignored by uri_encode (most are quite uncommon in http uris however.)

Thanks.