### PR TITLE
Fixed META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -9,7 +9,7 @@
     ],
     "depends" : [ ],
     "provides" : {
-      "URI::Encode" : "lib/Pod/Perl5.pm6"
+      "URI::Encode" : "lib/URI/Encode.pm6"
     },
     "source-type" : "git",
     "source-url" : "git://github.com/dnmfarrell/URI-Encode.git"


### PR DESCRIPTION
Now, URI::Encode can' t install via panda.
So fixed it.
```
$ panda install URI::Encode                                                                                                                     
==> Fetching URI::Encode
==> Building URI::Encode
==> Testing URI::Encode
t/Encode.t .. ok
All tests successful.
Files=1, Tests=16,  3 wallclock secs ( 0.04 usr  0.01 sys +  2.92 cusr  0.22 csys =  3.19 CPU)
Result: PASS
==> Installing URI::Encode
Failed to copy '/Users/matsuohiroki/Github/MyRepo/.panda-work/1449043155_1/lib/Pod/Perl5.pm6' to '/Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/28A77
46BBB1943A216135B6BDA87BCB85CAAC116': Failed to copy file: no such file or directory
  in any  at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/runtime/CORE.setting.moarvm:1
  in block  at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/A925F77B534FD0D133C11C8E9ADBCBAC0816A446:54
  in sub indir at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/1841ABA56602DF893F9A0C975AEF71F161A27ADA:20
  in method install at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/A925F77B534FD0D133C11C8E9ADBCBAC0816A446:41
  in method install at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/2435CF7C20787DAB8B49411BEBA2812038EC4849:146
  in method resolve at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/2435CF7C20787DAB8B49411BEBA2812038EC4849:219
  in sub MAIN at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/resources/E3E5DFC016C379AD6E9D305DA725C12041CCA814:18
  in block <unit> at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/resources/E3E5DFC016C379AD6E9D305DA725C12041CCA814:145

Actually thrown at:
  in any  at gen/moar/m-Metamodel.nqp:2883
  in block  at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/A925F77B534FD0D133C11C8E9ADBCBAC0816A446:54
  in sub indir at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/1841ABA56602DF893F9A0C975AEF71F161A27ADA:20
  in method install at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/A925F77B534FD0D133C11C8E9ADBCBAC0816A446:41
  in method install at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/2435CF7C20787DAB8B49411BEBA2812038EC4849:146
  in method resolve at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/sources/2435CF7C20787DAB8B49411BEBA2812038EC4849:219
  in sub MAIN at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/resources/E3E5DFC016C379AD6E9D305DA725C12041CCA814:18
  in block <unit> at /Users/matsuohiroki/.rakudobrew/moar-nom/install/share/perl6/site/resources/E3E5DFC016C379AD6E9D305DA725C12041CCA814:145
```